### PR TITLE
OL-4393 FIX Fixed Form radiogroups and HTML not being rendered properly

### DIFF
--- a/Common/HtmlRenderers/AbstractRenderer.php
+++ b/Common/HtmlRenderers/AbstractRenderer.php
@@ -17,6 +17,22 @@ abstract class AbstractRenderer implements RendererInterface
     use RendererTranslatorTrait;
     
 	protected RendererResolverInterface $resolver;
+
+    /**
+     * Resolve a JSON element, using this renderers resolver.
+     * 
+     * @param mixed $elementJson
+     * @param array $answerJson
+     * @return string
+     */
+    protected function resolveElement(mixed $elementJson, array $answerJson) : string
+    {
+        if(is_array($elementJson)) {
+            return $this->resolver->findRenderer($elementJson)->render($elementJson, $answerJson);
+        } else {
+            return $this->translateElement($elementJson);
+        }
+    }
     
     /**
      *

--- a/Common/HtmlRenderers/AbstractRenderer.php
+++ b/Common/HtmlRenderers/AbstractRenderer.php
@@ -3,17 +3,21 @@ namespace axenox\SurveyPrinter\Common\HtmlRenderers;
 
 use axenox\SurveyPrinter\Interfaces\RendererInterface;
 use axenox\SurveyPrinter\Interfaces\RendererResolverInterface;
+use axenox\SurveyPrinter\Traits\RendererTranslatorTrait;
 
 /**
- * This is an abstract class used if the renderer has elements and needs an resolver to find the right renderer for them.
+ * This is an abstract class used if the renderer has elements and needs a resolver to find the right renderer for
+ * them.
  * 
  * @author miriam.seitz
  *
  */
 abstract class AbstractRenderer implements RendererInterface
 {
+    use RendererTranslatorTrait;
+    
 	protected RendererResolverInterface $resolver;
-
+    
     /**
      *
      * @param RendererResolverInterface $resolver
@@ -31,7 +35,7 @@ abstract class AbstractRenderer implements RendererInterface
 		}
 		if ($jsonPart['description'] !== null){
 			$html .= <<<HTML
-    		<div class='form-description'>{$jsonPart['description']}</div>
+    		<div class='form-description'>{$this->translateElement($jsonPart['description'])}</div>
  HTML;
 		}
 		
@@ -53,28 +57,8 @@ abstract class AbstractRenderer implements RendererInterface
 				$cssClass = 'form-page-title';
 		}
 
-        // TODO: This fix is brittle and must be implemented anywhere the title attribute is read.
-		// for some reason there is sometimes a `default` value and then a `de` value which actually represents what is shown as the
-        // title to the user. So the logic is we take the `de` value before we take the `default`.
-        // If both are empty we use the name of the jsonpart.
-        // Shouldn't we also check for other languages and how do we decide which we use, maybe take the selected language from the user?
-		if (is_array($jsonPart['title']) === true) {		    
-		    switch (true) {
-		        case $jsonPart['title']['de'] !== null && $jsonPart['title']['de'] !== '':
-		            $title = $jsonPart['title']['de'];
-		            break;
-		        case $jsonPart['title']['default'] !== null && $jsonPart['title']['default'] !== '':
-		            $title = $jsonPart['title']['default'];
-		            break;
-		        default:
-		            $title = $jsonPart['name'];		            
-		    }
-		} else {
-		    $title = $jsonPart['title'] ? $jsonPart['title'] : $jsonPart['name'];
-		}
-
 		return <<<HTML
-    		<h{$this->resolver->getLevel()} class='{$cssClass}' style='page-break-after: avoid;'>{$title}</h{$this->resolver->getLevel()}>
+    		<h{$this->resolver->getLevel()} class='{$cssClass}' style='page-break-after: avoid;'>{$this->translateElement($jsonPart['title'])}</h{$this->resolver->getLevel()}>
  HTML;
 	}
 }

--- a/Common/HtmlRenderers/AbstractRenderer.php
+++ b/Common/HtmlRenderers/AbstractRenderer.php
@@ -54,7 +54,24 @@ abstract class AbstractRenderer implements RendererInterface
 		}
 
         // TODO: This fix is brittle and must be implemented anywhere the title attribute is read.
-        $title = is_array($jsonPart['title']) ? $jsonPart['title']['default'] : $jsonPart['title'];
+		// for some reason there is sometimes a `default` value and then a `de` value which actually represents what is shown as the
+        // title to the user. So the logic is we take the `de` value before we take the `default`.
+        // If both are empty we use the name of the jsonpart.
+        // Shouldn't we also check for other languages and how do we decide which we use, maybe take the selected language from the user?
+		if (is_array($jsonPart['title']) === true) {		    
+		    switch (true) {
+		        case $jsonPart['title']['de'] !== null && $jsonPart['title']['de'] !== '':
+		            $title = $jsonPart['title']['de'];
+		            break;
+		        case $jsonPart['title']['default'] !== null && $jsonPart['title']['default'] !== '':
+		            $title = $jsonPart['title']['default'];
+		            break;
+		        default:
+		            $title = $jsonPart['name'];		            
+		    }
+		} else {
+		    $title = $jsonPart['title'] ? $jsonPart['title'] : $jsonPart['name'];
+		}
 
 		return <<<HTML
     		<h{$this->resolver->getLevel()} class='{$cssClass}' style='page-break-after: avoid;'>{$title}</h{$this->resolver->getLevel()}>

--- a/Common/HtmlRenderers/BooleanRenderer.php
+++ b/Common/HtmlRenderers/BooleanRenderer.php
@@ -1,14 +1,12 @@
 <?php
 namespace axenox\SurveyPrinter\Common\HtmlRenderers;
 
-use axenox\SurveyPrinter\Interfaces\RendererInterface;
-
 /**
  * The BooleanRenderer is for simple yes or no questions.
  * 
- * The configuration differs within the SurveyJs but the awnser json 
- * If true an false has no lable there is no extra information within the SurveyJs.
- * If they have specified lables it will be configured like this:
+ * The configuration differs within the SurveyJs but the answer json 
+ * If true a false has no label there is no extra information within the SurveyJs.
+ * If they have specified labels it will be configured like this:
  * "labelTrue": "itemA",
  * "labelFalse": "itemB"
  * 
@@ -25,23 +23,23 @@ class BooleanRenderer extends QuestionRenderer
      * {@inheritDoc}
      * @see \axenox\SurveyPrinter\Interfaces\RendererInterface::render()
      */
-	public function render(array $jsonPart, array $awnserJson) : string
+	public function render(array $jsonPart, array $answerJson) : string
 	{
-		if ($this->isPartOfAwnserJson($jsonPart, $awnserJson) === false) {
+		if ($this->isPartOfAnswerJson($jsonPart, $answerJson) === false) {
 			return '';
 		}
 		
-		$awnser = $awnserJson[$jsonPart['name']];
-		if ($awnser === true) {
-			$awnser = array_key_exists('labelTrue', $jsonPart) ? $jsonPart['labelTrue'] : "Ja";
+		$answer = $answerJson[$jsonPart['name']];
+		if ($answer === true) {
+			$answer = array_key_exists('labelTrue', $jsonPart) ? $jsonPart['labelTrue'] : "Ja";
 		}
-		else if ($awnser === false){
-			$awnser = array_key_exists('labelFalse', $jsonPart) ? $jsonPart['labelFalse'] : "Nein";
+		else if ($answer === false){
+			$answer = array_key_exists('labelFalse', $jsonPart) ? $jsonPart['labelFalse'] : "Nein";
 		}
 		else {
 			return '';
 		}		
 		
-		return $this->renderQuestion($jsonPart, $awnser);
+		return $this->renderQuestion($jsonPart, $answer);
     }
 }

--- a/Common/HtmlRenderers/ChoicesRenderer.php
+++ b/Common/HtmlRenderers/ChoicesRenderer.php
@@ -1,12 +1,10 @@
 <?php
 namespace axenox\SurveyPrinter\Common\HtmlRenderers;
 
-use axenox\SurveyPrinter\Interfaces\RendererInterface;
-
 /**
  * The ChoicesRenderer should be used to render SurveyJs elements with a ´choices´ array.
  * 
- * The configuration differs for both SurveyJs and awnser json.
+ * The configuration differs for both SurveyJs and answer json.
  * If the SurveyJs only contains values and no corresponding text (like a title) the json will look like this:
  * ´"choices": [
 		"item1",
@@ -30,9 +28,9 @@ use axenox\SurveyPrinter\Interfaces\RendererInterface;
  *		}
  *	]´
  * 
- * In the awnser json will either be one awnser:
+ * In the answer json will either be one answer:
  * ´"nameOfQuestion": "item1"´
- * or an array with multiple awnsers:
+ * or an array with multiple answer:
  * ´"nameOfQuestion": [
 		"item1",
 		"item2"
@@ -48,41 +46,41 @@ class ChoicesRenderer extends QuestionRenderer
      * {@inheritDoc}
      * @see \axenox\SurveyPrinter\Interfaces\RendererInterface::render()
      */
-    public function render(array $jsonPart, array $awnserJson): string
+    public function render(array $jsonPart, array $answerJson): string
     {
-    	if ($this->isPartOfAwnserJson($jsonPart, $awnserJson) === false) {
+    	if ($this->isPartOfAnswerJson($jsonPart, $answerJson) === false) {
     		return '';
     	}
     	
     	$choices = $jsonPart['choices'];
-    	$awnser = $awnserJson[$jsonPart['name']];    
+    	$answer = $answerJson[$jsonPart['name']];    
     		
     	$firstItem = true;
     	$showOtherItem = $jsonPart['showOtherItem'] ?? false;
     	$showNoneItem = $jsonPart['showNoneItem'] ?? false;
     	
     	switch (true){
-        case $awnser == 'other' && $showOtherItem === true:
-            $otherComment = $awnserJson[$jsonPart['name'] . '-Comment'];
-            $values = $jsonPart['otherText'] . ($otherComment ? ' - ' . $otherComment : '');
-            break;
-        case $awnser == 'none' && $showNoneItem === true:
-            $values = '';
-            break;
-        default:
-            foreach ($choices as $choice){
-                $value = null;
-                if (is_array($choice)) {
-                    $value = $this->evaluateItemWithMoreInformation($choice, $awnser);
-                } else {
-                    $value = $this->evaluateItem($choice,$awnser);
+            case $answer == 'other' && $showOtherItem === true:
+                $otherComment = $answerJson[$jsonPart['name'] . '-Comment'];
+                $values = $jsonPart['otherText'] . ($otherComment ? ' - ' . $otherComment : '');
+                break;
+            case $answer == 'none' && $showNoneItem === true:
+                $values = '';
+                break;
+            default:
+                $values = '';
+                foreach ($choices as $choice){
+                    if (is_array($choice)) {
+                        $value = $this->evaluateItemWithMoreInformation($choice, $answer);
+                    } else {
+                        $value = $this->evaluateItem($choice,$answer);
+                    }
+                    
+                    if ($value !== null){
+                        $values .= $firstItem ? $value : ', ' . $value;
+                        $firstItem = false;
+                    }
                 }
-                
-                if ($value !== null){
-                    $values .= $firstItem ? $value : ', ' . $value;
-                    $firstItem = false;
-                }
-            }
     	}
     	return $this->renderQuestion($jsonPart, $values);
     }
@@ -95,48 +93,48 @@ class ChoicesRenderer extends QuestionRenderer
      *  }
      * 
      * @param array $choice
-     * @param mixed $awnser can be either an array or a string
+     * @param mixed $answer can be either an array or a string
      * @return string|NULL
      */
-    protected function evaluateItemWithMoreInformation(array $choice, mixed $awnser) : ?string
+    protected function evaluateItemWithMoreInformation(array $choice, mixed $answer) : ?string
     {
-    	if ($this->matchAwnser($choice['value'], $awnser)){
+    	if ($this->matchAnswer($choice['value'], $answer)){
     		return $choice['text'];
     	}
     	
     	return null;
     }
-    
+
     /**
      * Evaluates a choice when it is only a value: "item1"
-     * 
-     * @param array $choice
-     * @param mixed $awnser can be either an array or a string
+     *
+     * @param string $choice
+     * @param mixed  $answer can be either an array or a string
      * @return string|NULL
      */
-    protected function evaluateItem(string $choice, mixed $awnser) : ?string 
+    protected function evaluateItem(string $choice, mixed $answer) : ?string 
     {
-    	if ($this->matchAwnser($choice, $awnser)){
+    	if ($this->matchAnswer($choice, $answer)){
     		return $choice;
     	}
     	
     	return null;
     }
     
-    protected function matchAwnser(string $choice, mixed $awnser) : bool
+    protected function matchAnswer(string $choice, mixed $answer) : bool
     {
-    	return is_array($awnser) ? 
-	    	$this->searchValueInMultipleAwnsers($choice, $awnser) : 
-	    	$this->matchWithAwnser($choice, $awnser);
+    	return is_array($answer) ? 
+	    	$this->searchValueInMultipleAnswers($choice, $answer) : 
+	    	$this->matchWithAnswer($choice, $answer);
     }
     
-    protected function searchValueInMultipleAwnsers(string $choice, array $awnserArray) : bool
+    protected function searchValueInMultipleAnswers(string $choice, array $answerArray) : bool
     {
-    	return in_array($choice, $awnserArray);
+    	return in_array($choice, $answerArray);
     }
     
-    protected function matchWithAwnser(string $choice, string $awnser) : bool
+    protected function matchWithAnswer(string $choice, string $answer) : bool
     {
-    	return $choice === $awnser;
+    	return $choice === $answer;
     }
 }

--- a/Common/HtmlRenderers/DynamicPanelRenderer.php
+++ b/Common/HtmlRenderers/DynamicPanelRenderer.php
@@ -7,7 +7,7 @@ class DynamicPanelRenderer extends AbstractRenderer
      * This renderer is a strict renderer for panels of a SurveyJs.
 	 * The SurveyJs has to have an array ´templateElements´ that contains all related elements.
 	 * 
-	 * The awnser json for this panel is related to the panel with an inner layer to pass for the other elements.
+	 * The answer json for this panel is related to the panel with an inner layer to pass for the other elements.
 	 * ´"dynamicPanelName": [
 	 *	{
 	 *		"elementName": "Text",
@@ -18,14 +18,14 @@ class DynamicPanelRenderer extends AbstractRenderer
 	 *		"elementName2": false,
 	 *	}
 	 * ]´
-	 * (!) The elementNames in the dynamic panel will be equal but seperate objects in the array.
+	 * (!) The elementNames in the dynamic panel will be equal but separate objects in the array.
 	 * 
  	 * @author miriam.seitz
      */
-	public function render(array $jsonPart, array $awnserJson) : string
+	public function render(array $jsonPart, array $answerJson) : string
     {    	
     	$attributes = $this->renderAttributesToRender($jsonPart);
-    	$renderedElements =$this->renderElements($jsonPart, $awnserJson[$jsonPart['name']]);
+    	$renderedElements = $this->renderElements($jsonPart, $answerJson[$jsonPart['name']]);
     	if ($renderedElements === ''){
     		return '';
     	}
@@ -39,28 +39,30 @@ class DynamicPanelRenderer extends AbstractRenderer
 HTML;
     }
 
-    
+
     /**
      *
      * @param array $jsonPart
+     * @param array $answerJson
      * @return string
      */
-    public function renderElements(array $jsonPart, array $awnserJson) : string
+    public function renderElements(array $jsonPart, array $answerJson) : string
     {
-    	//elements should be on the next level
+    	// Elements should be on the next level.
     	$this->resolver->increaseLevel();
-    	// muiltiple panels with awnsers
-	    foreach($awnserJson as  $entry) {
+    	// Multiple panels with answer.
+        $html = '';
+	    foreach($answerJson as $entry) {
 			foreach ($jsonPart['templateElements'] as $element) {
-				// element is an array
-				if (is_numeric($element)) {
+				// Element is an array
+				if (is_array($element)) {
 					foreach ($element as $jsonObject) {
 						$htmlElement = $this->resolver->findRenderer($jsonObject)->render($jsonObject, $entry);
 						$html .= $htmlElement;
 					}
 					continue;
 				}
-				// skip expressions in export
+				// Skip expressions in export
 				if (array_key_exists('type', $element) && $element['type'] === 'expression') {
 					continue;
 				} else {

--- a/Common/HtmlRenderers/DynamicPanelRenderer.php
+++ b/Common/HtmlRenderers/DynamicPanelRenderer.php
@@ -54,20 +54,11 @@ HTML;
         $html = '';
 	    foreach($answerJson as $entry) {
 			foreach ($jsonPart['templateElements'] as $element) {
-				// Element is an array
-				if (is_array($element)) {
-					foreach ($element as $jsonObject) {
-						$htmlElement = $this->resolver->findRenderer($jsonObject)->render($jsonObject, $entry);
-						$html .= $htmlElement;
-					}
-					continue;
-				}
 				// Skip expressions in export
 				if (array_key_exists('type', $element) && $element['type'] === 'expression') {
 					continue;
 				} else {
-					$htmlElement = $this->resolver->findRenderer($element)->render($element, $entry);
-					$html .= $htmlElement;
+					$html .= $this->resolveElement($element, $entry);
 				}
 			}
 	    }

--- a/Common/HtmlRenderers/HtmlRenderer.php
+++ b/Common/HtmlRenderers/HtmlRenderer.php
@@ -1,10 +1,8 @@
 <?php
 namespace axenox\SurveyPrinter\Common\HtmlRenderers;
 
-use axenox\SurveyPrinter\Interfaces\RendererInterface;
-
 /**
- * The HTML Renderer is for survey parts of the type html, we just return the html wrapped in a div to avoid page breake inside and after the html.
+ * The HTML Renderer is for survey parts of the type html, we just return the html wrapped in a div to avoid page break inside and after the html.
  * 
  * @author ralf.mulansky
  *
@@ -16,14 +14,10 @@ class HtmlRenderer extends AbstractRenderer
      * {@inheritDoc}
      * @see \axenox\SurveyPrinter\Interfaces\RendererInterface::render()
      */
-    public function render(array $jsonPart, array $awnserJson): string
+    public function render(array $jsonPart, array $answerJson): string
     {
     	if (($html = $jsonPart['html']) !== null) {
-            // TODO geb 2024-11-28: This may be an array, because the form offers localization options (i.e. ['de' => html, 'en' => html, ...])
-            // TODO We don't really use this feature at the moment, so we are just using the first option, hoping that it is the default.
-            if(is_array($html)) {
-                $html = $html[array_key_first($html)];
-            }
+            $html = $this->translateElement($html);
     	    return <<<html
     	    <div style='page-break-after: avoid; page-break-inside: avoid;'>{$html}</div>
 html;

--- a/Common/HtmlRenderers/HtmlRenderer.php
+++ b/Common/HtmlRenderers/HtmlRenderer.php
@@ -18,9 +18,14 @@ class HtmlRenderer extends AbstractRenderer
      */
     public function render(array $jsonPart, array $awnserJson): string
     {
-    	if ($jsonPart['html']) {
+    	if (($html = $jsonPart['html']) !== null) {
+            // TODO geb 2024-11-28: This may be an array, because the form offers localization options (i.e. ['de' => html, 'en' => html, ...])
+            // TODO We don't really use this feature at the moment, so we are just using the first option, hoping that it is the default.
+            if(is_array($html)) {
+                $html = $html[array_key_first($html)];
+            }
     	    return <<<html
-    	    <div style='page-break-after: avoid; page-break-inside: avoid;'>{$jsonPart['html']}</div>
+    	    <div style='page-break-after: avoid; page-break-inside: avoid;'>{$html}</div>
 html;
     	}
     		

--- a/Common/HtmlRenderers/InvisibleRenderer.php
+++ b/Common/HtmlRenderers/InvisibleRenderer.php
@@ -13,7 +13,7 @@ class InvisibleRenderer implements RendererInterface
 	 */
 	public function render(
 		array $jsonPart,
-		array $awnserJson): string
+		array $answerJson): string
 	{
 		return '';
 	}

--- a/Common/HtmlRenderers/MatrixRenderer.php
+++ b/Common/HtmlRenderers/MatrixRenderer.php
@@ -1,7 +1,6 @@
 <?php
 namespace axenox\SurveyPrinter\Common\HtmlRenderers;
 
-use axenox\SurveyPrinter\Interfaces\RendererInterface;
 use exface\Core\DataTypes\DateDataType;
 use exface\Core\DataTypes\DateTimeDataType;
 
@@ -81,7 +80,7 @@ use exface\Core\DataTypes\DateTimeDataType;
  *		}
  *	},
  * ]´
- * (!) Columns and rows of matrices without choices show columns with ´value´ and ´text´ while matrix with ´choices´ show ONLY IN COLUMNS the schema of ´name´ and ´title´ (this sould be reported to SurveyJs)
+ * (!) Columns and rows of matrices without choices show columns with ´value´ and ´text´ while matrix with ´choices´ show ONLY IN COLUMNS the schema of ´name´ and ´title´ (this should be reported to SurveyJs)
  *
  * @author miriam.seitz
  */
@@ -102,7 +101,8 @@ class MatrixRenderer extends AbstractRenderer
     			$tableHeader .= '<th>' . $column . '</th>';
     		} else {
     			// this is ugly because SurveyJs made something foolish (see last summary entry)
-	    		$tableHeader .= '<th>' . ($column['text'] ?? $column['value'] ?? $column['title'] ?? $column['name']) . '</th>';
+                $value = $this->translateElement($column['text'] ?? $column['value'] ?? $column['title'] ?? $column['name']);
+	    		$tableHeader .= '<th>' . $value . '</th>';
     		}
     	}
 
@@ -114,22 +114,24 @@ class MatrixRenderer extends AbstractRenderer
     			$rowName = $row;
     			$tableContent .= '<td class=' . $rowEntryTitleCssClass .'>' . $row . '</td>';
     		} else {
-    			$rowName = $row['value'];
-    			$tableContent .= '<td class=' . $rowEntryTitleCssClass .'>'. ($row['text'] ?? $row['value']) . '</td>';
+    			$rowName = $this->translateElement($row['value']);
+                $value = $this->translateElement($row['text'] ?? $row['value']);
+    			$tableContent .= '<td class=' . $rowEntryTitleCssClass .'>'. $value . '</td>';
     		}
 
     		$answer = $answerJson[$jsonPart['name']][$rowName];
     		foreach ($jsonPart['columns'] as $column) {
-    			if (array_key_exists('choices', $jsonPart)) {
-    				$columnName = is_string($column) ? $column : $column['name'];
+                $columnName = is_string($column) ? $column : $column['name'];
+                if (array_key_exists('choices', $jsonPart)) {
                     $output = $this->matchChoiceWithAnswer($jsonPart['choices'], $answer, $columnName);
+                    $output = $this->translateElement($output);
     				$tableContent .= '<td>' . $this->handleCellTypes($output) . '</td>';
 	    		} else {
-	    			$columnName = is_string($column) ? $column : $column['name'];
                     if(is_string($answer)) {
 	    			    $tableContent .= '<td>' . ($answer === $columnName ? 'X' : '') . '</td>';
                     } else {
-                        $tableContent .= '<td>' . $this->handleCellTypes($answer[$columnName]). '</td>';
+                        $value = $this->translateElement($answer[$columnName]);
+                        $tableContent .= '<td>' . $this->handleCellTypes($value). '</td>';
                     }
 	    		}
     		}
@@ -161,7 +163,7 @@ HTML;
      * Checks whether a string matches a certain cell type (i.e. a date or date-time) and
      * formats it accordingly.
      *
-     * @param string $input
+     * @param string|null $input
      * @return string
      */
     private function handleCellTypes(?string $input) : string
@@ -185,14 +187,15 @@ HTML;
      * Evaluates the choice either
      * with text
      *  {
-     * 		"value": "item1",
-     * 		"text": "A"
+     *        "value": "item1",
+     *        "text": "A"
      *  }
      * or without:
      * value: "item1"
      *
-     * @param array $choices
-     * @param mixed $answer can be either an array, a string or null
+     * @param array  $choices
+     * @param mixed  $answer can be either an array, a string or null
+     * @param string $columnName
      * @return string|NULL
      */
     protected function matchChoiceWithAnswer(array $choices, mixed $answer, string $columnName) : ?string

--- a/Common/HtmlRenderers/MultipleTextRenderer.php
+++ b/Common/HtmlRenderers/MultipleTextRenderer.php
@@ -6,9 +6,9 @@ class MultipleTextRenderer extends AbstractRenderer
     /**
  	 * The MultipleTextRenderer is a strict renderer for the multiple text element of SurveyJs.
 	 * The SurveyJs has to have an array ´items´ that contains only the ´name´ of the question.
-	 * This means only the TextRenderer can be used for it's child elements.
+	 * This means only the TextRenderer can be used for its child elements.
 	 * 
-	 * The awnser json will be contributed to all inner text elements and looks like this:
+	 * The answer json will be contributed to all inner text elements and looks like this:
  	 * "multiTextName": {
 	 *	 "textName1": "Test2",
 	 *	 "textName2": "Test2"
@@ -17,32 +17,33 @@ class MultipleTextRenderer extends AbstractRenderer
      * {@inheritDoc}
      * @see \axenox\SurveyPrinter\Interfaces\RendererInterface::render()
      */
-	public function render(array $jsonPart, array $awnserJson) : string
+	public function render(array $jsonPart, array $answerJson) : string
     {        
-    	$renderedElements =$this->renderElements($jsonPart, $awnserJson[$jsonPart['name']]);
+    	$renderedElements = $this->renderElements($jsonPart, $answerJson[$jsonPart['name']]);
     	if ($renderedElements === ''){
     		return '';
     	}
     	
         return <<<HTML
-    <label class='form-panelTitle'>{$jsonPart['title']}</label>
+    <label class='form-panelTitle'>{$this->translateElement($jsonPart['title'])}</label>
 	<div class='form-items'>
 		{$renderedElements}
 	</div>
 HTML;
     }
 
-    
+
     /**
      *
      * @param array $jsonPart
+     * @param array $answerJson
      * @return string
      */
-    public function renderElements(array $jsonPart, array $awnserJson) : string
+    public function renderElements(array $jsonPart, array $answerJson) : string
     {
     	$html = '';
     	foreach ($jsonPart['items'] as $el) {
-    		$html .= (new TextRenderer($this->resolver))->render($el, $awnserJson);
+    		$html .= (new TextRenderer())->render($el, $answerJson);
     	}
     	
     	return $html;

--- a/Common/HtmlRenderers/NotFoundRenderer.php
+++ b/Common/HtmlRenderers/NotFoundRenderer.php
@@ -10,7 +10,7 @@ class NotFoundRenderer implements RendererInterface
      * 
 	 * @author miriam.seitz
      */
-    public function render(array $jsonPart, array $awnserJson): string
+    public function render(array $jsonPart, array $answerJson): string
     {
     	return <<<HTML
     	

--- a/Common/HtmlRenderers/PageRenderer.php
+++ b/Common/HtmlRenderers/PageRenderer.php
@@ -5,7 +5,7 @@ class PageRenderer extends AbstractRenderer
 {	
 	/**
 	 * The PageRenderer is a strict renderer for pages of a SurveyJs.
-	 * The SurveyJs has to have an array ´pages´ and these have to to have ojects with ´elements´ that contains all related elements.
+	 * The SurveyJs has to have an array ´pages´ and these have to have objects with ´elements´ that contains all related elements.
 	 * SurveyJs for all pages:
 	 * "title": "Form", // optional
 	 * "pages": [ .. ]
@@ -15,12 +15,12 @@ class PageRenderer extends AbstractRenderer
 	 * "title": "Page" // optional 
 	 * "elements": [ ... ]
 	 * 
-	 * The awnser json will be contributed to all inner elements.
+	 * The answer json will be contributed to all inner elements.
 	 * 
 	 * {@inheritDoc}
 	 * @see \axenox\SurveyPrinter\Interfaces\RendererInterface::render()
 	 */
-    public function render(array $jsonPart, array $awnserJson): string
+    public function render(array $jsonPart, array $answerJson): string
     {    	
     	switch(true)
     	{
@@ -32,6 +32,9 @@ class PageRenderer extends AbstractRenderer
     			$cssClass = 'form-page';
     			$elements = $jsonPart['elements'];
     			break;
+            default:
+                $cssClass = '';
+                $elements = [];
     	}
     	
     	$attributes = $this->renderAttributesToRender($jsonPart);
@@ -39,18 +42,19 @@ class PageRenderer extends AbstractRenderer
         	
 	<div class='{$cssClass}'>
 		{$attributes}
-		{$this->renderElements($elements, $awnserJson)}
+		{$this->renderElements($elements, $answerJson)}
 		{$this->createFooter($jsonPart)}
 	</div>
 HTML;
     }
 
     /**
-     * 
-     * @param array $jsonPart
+     *
+     * @param array $elements
+     * @param array $answerJson
      * @return string
      */
-    public function renderElements(array $elements, array $awnserJson) : string
+    public function renderElements(array $elements, array $answerJson) : string
     {        
     	$html = '';
         
@@ -58,9 +62,9 @@ HTML;
         $this->resolver->increaseLevel();
         foreach ($elements as $el) {
         	// element is an array
-        	if (is_numeric($el)) {
+        	if (is_array($el)) {
         		foreach ($el as $jsonElement) {
-        			$htmlElement = $this->resolver->findRenderer($jsonElement)->render($jsonElement, $awnserJson);
+        			$htmlElement = $this->resolver->findRenderer($jsonElement)->render($jsonElement, $answerJson);
         			$html .= $htmlElement;
         		}
         		continue;
@@ -69,7 +73,7 @@ HTML;
         	if (array_key_exists('type', $el) && $el['type'] === 'expression') {
         		continue;
         	} else {
-        		$htmlElement = $this->resolver->findRenderer($el)->render($el, $awnserJson);
+        		$htmlElement = $this->resolver->findRenderer($el)->render($el, $answerJson);
         		$html .= $htmlElement;
         	}
         }

--- a/Common/HtmlRenderers/PageRenderer.php
+++ b/Common/HtmlRenderers/PageRenderer.php
@@ -61,20 +61,11 @@ HTML;
         //elements should be on the next level
         $this->resolver->increaseLevel();
         foreach ($elements as $el) {
-        	// element is an array
-        	if (is_array($el)) {
-        		foreach ($el as $jsonElement) {
-        			$htmlElement = $this->resolver->findRenderer($jsonElement)->render($jsonElement, $answerJson);
-        			$html .= $htmlElement;
-        		}
-        		continue;
-        	}
         	// skip expressions in export
         	if (array_key_exists('type', $el) && $el['type'] === 'expression') {
         		continue;
         	} else {
-        		$htmlElement = $this->resolver->findRenderer($el)->render($el, $answerJson);
-        		$html .= $htmlElement;
+        		$html .= $this->resolveElement($el, $answerJson);
         	}
         }
         $this->resolver->decreaseLevel();

--- a/Common/HtmlRenderers/PanelRenderer.php
+++ b/Common/HtmlRenderers/PanelRenderer.php
@@ -39,6 +39,7 @@ HTML;
     {
     	//elements should be on the next level
     	$this->resolver->increaseLevel();
+        $html = '';
     	foreach ($jsonPart['elements'] as $el) {
     		// element is an array
     		if (is_numeric($el)){

--- a/Common/HtmlRenderers/PanelRenderer.php
+++ b/Common/HtmlRenderers/PanelRenderer.php
@@ -7,15 +7,15 @@ class PanelRenderer extends AbstractRenderer
      * This renderer is a strict renderer for panels of a SurveyJs.
 	 * The SurveyJs has to have an array ´elements´ that contains all related elements.
 	 * 
-	 * The awnser json will be contributed to all inner elements.
+	 * The answer json will be contributed to all inner elements.
 	 * 
      * {@inheritDoc}
      * @see \axenox\SurveyPrinter\Interfaces\RendererInterface::render()
      */
-	public function render(array $jsonPart, array $awnserJson) : string
+	public function render(array $jsonPart, array $answerJson) : string
 	{
 		$attributes = $this->renderAttributesToRender($jsonPart);
-    	$renderedElements = $this->renderElements($jsonPart, $awnserJson);
+    	$renderedElements = $this->renderElements($jsonPart, $answerJson);
     	if ($renderedElements === ''){
     		return '';
     	}
@@ -29,22 +29,23 @@ class PanelRenderer extends AbstractRenderer
 HTML;
     }
 
-    
+
     /**
      *
      * @param array $jsonPart
+     * @param array $answerJson
      * @return string
      */
-    public function renderElements(array $jsonPart, array $awnserJson) : string
+    public function renderElements(array $jsonPart, array $answerJson) : string
     {
     	//elements should be on the next level
     	$this->resolver->increaseLevel();
         $html = '';
     	foreach ($jsonPart['elements'] as $el) {
     		// element is an array
-    		if (is_numeric($el)){
+    		if (is_array($el)){
     			foreach ($el as $jsonElement) {
-    				$html .= $this->resolver->findRenderer($jsonElement)->render($jsonElement, $awnserJson);
+    				$html .= $this->resolver->findRenderer($jsonElement)->render($jsonElement, $answerJson);
     			}
     			continue;
     		}
@@ -52,7 +53,7 @@ HTML;
     		if (array_key_exists('type', $el) && $el['type'] === 'expression') {
     			continue;
     		} else {
-    			$html .= $this->resolver->findRenderer($el)->render($el, $awnserJson);
+    			$html .= $this->resolver->findRenderer($el)->render($el, $answerJson);
     		}
     	}
     	$this->resolver->decreaseLevel();

--- a/Common/HtmlRenderers/PanelRenderer.php
+++ b/Common/HtmlRenderers/PanelRenderer.php
@@ -42,18 +42,11 @@ HTML;
     	$this->resolver->increaseLevel();
         $html = '';
     	foreach ($jsonPart['elements'] as $el) {
-    		// element is an array
-    		if (is_array($el)){
-    			foreach ($el as $jsonElement) {
-    				$html .= $this->resolver->findRenderer($jsonElement)->render($jsonElement, $answerJson);
-    			}
-    			continue;
-    		}
     		// skip expressions in export
     		if (array_key_exists('type', $el) && $el['type'] === 'expression') {
     			continue;
     		} else {
-    			$html .= $this->resolver->findRenderer($el)->render($el, $answerJson);
+    			$html .= $this->resolveElement($el, $answerJson);
     		}
     	}
     	$this->resolver->decreaseLevel();

--- a/Common/HtmlRenderers/QuestionRenderer.php
+++ b/Common/HtmlRenderers/QuestionRenderer.php
@@ -33,9 +33,23 @@ HTML;
     protected function renderQuestion(array $jsonPart, string $renderedValues)
     {
         // TODO: This fix is brittle and must be implemented anywhere the title attribute is read.
+        // For some reason there is sometimes a `default` value and then a `de` value which actually represents what is shown as the
+        // title to the user. So the logic is we take the `de` value before we take the `default`.
+        // If both are empty we use the name of the jsonpart.
+        // Shouldn't we also check for other languages and how do we decide which we use, maybe take the selected language from the user?
     	$title = $jsonPart['title'] ?? $jsonPart['name'];
         if(is_array($title)) {
             $label = $title['default'];
+            switch (true) {
+                case $title['de'] !== null && $title['de'] !== '':
+                    $label = $title['de'];
+                    break;
+                case $title['default'] !== null && $title['default'] !== '':
+                    $label = $title['default'];
+                    break;
+                default:
+                    $label = $jsonPart['name'];
+            }
         } else {
             $label = $title;
         }

--- a/Common/HtmlRenderers/QuestionRenderer.php
+++ b/Common/HtmlRenderers/QuestionRenderer.php
@@ -2,72 +2,54 @@
 namespace axenox\SurveyPrinter\Common\HtmlRenderers;
 
 use axenox\SurveyPrinter\Interfaces\RendererInterface;
+use axenox\SurveyPrinter\Traits\RendererTranslatorTrait;
 
 /**
- * The QuestionRenderer is an abstract class ensuring the context of every renderer that deals with awnsers.
+ * The QuestionRenderer is an abstract class ensuring the context of every renderer that deals with answers.
  *
  * @author miriam.seitz
  *
  */
 abstract class QuestionRenderer implements RendererInterface
-{	    
-    protected function isPartOfAwnserJson(array $jsonPart, array $awnserJson) : bool
+{
+    use RendererTranslatorTrait;
+    
+    protected function isPartOfAnswerJson(array $jsonPart, array $answerJson) : bool
     {
-    	if ($awnserJson[$jsonPart['name']] !== null) {
+    	if ($answerJson[$jsonPart['name']] !== null) {
     		return true;
     	}
     	
     	return false;
     }
     
-    protected function renderDescriptionIfAvailable(array $jsonPart) {
+    protected function renderDescriptionIfAvailable(array $jsonPart) : string
+    {
     	if (array_key_exists('description', $jsonPart) === false){
     		return '';
     	}
     	
     	return <<<HTML
-    	<td class='form-description'>{$jsonPart['description']}</td>
+    	<td class='form-description'>{$this->translateElement($jsonPart['description'])}</td>
 HTML;
     }
     	
-    protected function renderQuestion(array $jsonPart, string $renderedValues)
+    protected function renderQuestion(array $jsonPart, string $renderedValues) : string
     {
-        // TODO: This fix is brittle and must be implemented anywhere the title attribute is read.
-        // For some reason there is sometimes a `default` value and then a `de` value which actually represents what is shown as the
-        // title to the user. So the logic is we take the `de` value before we take the `default`.
-        // If both are empty we use the name of the jsonpart.
-        // Shouldn't we also check for other languages and how do we decide which we use, maybe take the selected language from the user?
-    	$title = $jsonPart['title'] ?? $jsonPart['name'];
-        if(is_array($title)) {
-            $label = $title['default'];
-            switch (true) {
-                case $title['de'] !== null && $title['de'] !== '':
-                    $label = $title['de'];
-                    break;
-                case $title['default'] !== null && $title['default'] !== '':
-                    $label = $title['default'];
-                    break;
-                default:
-                    $label = $jsonPart['name'];
-            }
-        } else {
-            $label = $title;
-        }
+    	$label = $this->translateElement($jsonPart['title'] ?? $jsonPart['name']);
+    	$description = $this->translateElement($this->renderDescriptionIfAvailable($jsonPart));
 
-    	$description = $this->renderDescriptionIfAvailable($jsonPart);  
-    	
-    	switch ($jsonPart['type']){
-    		case 'text';
-    			$additionalCssClass = ' form-text';
-    			break;
-    	}
+        $additionalCssClass = match ($jsonPart['type']) {
+            'text' => ' form-text',
+            default => '',
+        };
     	
     	return <<<HTML
     		
 	<table class='form-question{$additionalCssClass}'>
 		<tr>
 			<td>{$label}</td>
-			<td class='form-value'>{$renderedValues}</td>
+			<td class='form-value'>{$this->translateElement($renderedValues)}</td>
 			{$description}
 		</tr>
 	</table>

--- a/Common/HtmlRenderers/SurveyRenderer.php
+++ b/Common/HtmlRenderers/SurveyRenderer.php
@@ -9,6 +9,7 @@ use exface\Core\Exceptions\Configuration\ConfigOptionNotFoundError;
 use exface\Core\CommonLogic\Workbench;
 use exface\Core\Interfaces\ConfigurationInterface;
 use exface\Core\Interfaces\WorkbenchInterface;
+use exface\Core\Interfaces\Log\LoggerInterface;
 
 /**
  * The SurveyRenderer takes a SurveyJs and tries to resolve all it's elements. He needs an array of all renderers by type
@@ -66,7 +67,7 @@ class SurveyRenderer implements RendererInterface,  RendererResolverInterface
     	if (array_key_exists($jsonPart['type'], $this->renderersByType) === false){
     		$this->workbench->getLogger()->logException(new ConfigOptionNotFoundError(
     			$this->config,
-    			'Unknown render target type: ' . $jsonPart['type']));
+    		    'Unknown render target type: ' . $jsonPart['type']), LoggerInterface::ERROR);
     		return new InvisibleRenderer($this); // TODO: delete when not found handler implemented
     		// return new NotFoundRenderer($this); 
     	}

--- a/Common/HtmlRenderers/SurveyRenderer.php
+++ b/Common/HtmlRenderers/SurveyRenderer.php
@@ -1,7 +1,6 @@
 <?php
 namespace axenox\SurveyPrinter\Common\HtmlRenderers;
 
-use axenox\SurveyPrinter\Formulas\SurveyAsHTML;
 use axenox\SurveyPrinter\Interfaces\RendererInterface;
 use axenox\SurveyPrinter\Interfaces\RendererResolverInterface;
 use exface\Core\Exceptions\InvalidArgumentException;
@@ -47,10 +46,11 @@ class SurveyRenderer implements RendererInterface,  RendererResolverInterface
     	$this->headingLevel = $headingLevel;
     	return $this->createStyleHeader($cssPath) . $this->renderElements($surveyJson, $answerJson);
     }
-    
+
     /**
      *
      * @param array $json
+     * @param       $answerJson
      * @return string
      */
     public function renderElements(array $json, $answerJson) : string

--- a/Common/HtmlRenderers/TextRenderer.php
+++ b/Common/HtmlRenderers/TextRenderer.php
@@ -5,9 +5,9 @@ use axenox\SurveyPrinter\Interfaces\RendererInterface;
 
 /**
  * The TextRenderer is for simple questions with text output.
- * The element of the SurveyJs should not contain any predefined awnsers
- * and the awnser json should contain the text under the name of the related question:
- * ´"NameOfQuerstion": "Text",´
+ * The element of the SurveyJs should not contain any predefined answers
+ * and the answer json should contain the text under the name of the related question:
+ * ´"NameOfQuestion": "Text",´
  * 
  * @author miriam.seitz
  *
@@ -19,12 +19,12 @@ class TextRenderer extends QuestionRenderer
      * {@inheritDoc}
      * @see \axenox\SurveyPrinter\Interfaces\RendererInterface::render()
      */
-    public function render(array $jsonPart, array $awnserJson): string
+    public function render(array $jsonPart, array $answerJson): string
     {
-    	if ($this->isPartOfAwnserJson($jsonPart, $awnserJson) === false) {
+    	if ($this->isPartOfAnswerJson($jsonPart, $answerJson) === false) {
     		return '';
     	}
     		
-    	return $this->renderQuestion($jsonPart, $awnserJson[$jsonPart['name']]);
+    	return $this->renderQuestion($jsonPart, $answerJson[$jsonPart['name']]);
     }
 }

--- a/Config/axenox.SurveyPrinter.config.json
+++ b/Config/axenox.SurveyPrinter.config.json
@@ -5,6 +5,7 @@
 		 "boolean": "\\axenox\\SurveyPrinter\\Common\\HtmlRenderers\\BooleanRenderer",	
 		 "dropdown": "\\axenox\\SurveyPrinter\\Common\\HtmlRenderers\\ChoicesRenderer",
 		 "checkbox": "\\axenox\\SurveyPrinter\\Common\\HtmlRenderers\\ChoicesRenderer",
+		 "radiogroup": "\\axenox\\SurveyPrinter\\Common\\HtmlRenderers\\ChoicesRenderer",
 		 "panel": "\\axenox\\SurveyPrinter\\Common\\HtmlRenderers\\PanelRenderer",
 		 "paneldynamic": "\\axenox\\SurveyPrinter\\Common\\HtmlRenderers\\DynamicPanelRenderer",
 		 "multipletext": "\\axenox\\SurveyPrinter\\Common\\HtmlRenderers\\MultipleTextRenderer",

--- a/Traits/RendererTranslatorTrait.php
+++ b/Traits/RendererTranslatorTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace axenox\SurveyPrinter\Traits;
+
+/**
+ * Allows a renderer translate elements, before writing them to their output HTML.
+ */
+trait RendererTranslatorTrait
+{
+    /**
+     * Translate an element.
+     *
+     * If `$element` is a localization array, this function translates it accordingly.
+     * Otherwise, it returns the element as is.
+     *
+     * @param mixed $element
+     * @return string|array
+     */
+    protected function translateElement(mixed $element) : string|array
+    {
+        if (!is_array($element)) {
+            return $element;
+        }
+
+        $locale = $this->getLocale();
+        return match (true) {
+            key_exists($locale, $element) => $element[$locale],
+            key_exists('default', $element) => $element['default'],
+            default => $element[array_key_first($element)],
+        };
+    }
+        
+    /**
+     * Get the locale for localization.
+     *
+     * TODO 2024-11-28 geb: This is a placeholder implementation.
+     *
+     * @return string
+     */
+    protected function getLocale() : string
+    {
+        return 'de';
+    }
+}


### PR DESCRIPTION
### Changes
- Added `'radiogroup'` to config mapped to `ChoicesRenderer`
- Added element translation to all renderers. This should fix a reoccurring issue where content with localization options would be displayed as string `"array"` instead of its actual content.
- Fixed some typos
- Minor improvements and cleanup

### Notes
- Localization is a stub at the moment. If we want to use this feature in the future we need to extend it.